### PR TITLE
Add register ranges in config file instead of hardcoding in script

### DIFF
--- a/diematic.yaml.orig
+++ b/diematic.yaml.orig
@@ -1,11 +1,20 @@
 logging: critical
 
+
+# Modbus connection parameters
+# The 'register_ranges' indicates the ranges of ids to be read
+# from the device, to avoid reading lots of useless data.
+# All registers ids listed in the 'registers' section below
+# must be included in a range, otherwise they will be ignored.
 modbus:
     retries: 3
     unit: 10
     device: /dev/ttyUSB0
     timeout: 10
     baudrate: 9600
+    register_ranges:
+      - [ 600, 620]
+      - [ 700, 702]
 
 influxdb:
     host: localhost


### PR DESCRIPTION
When trying to add new values, like for example the water tank temperature setpoint (id 59), at first I didn't understand why it wouldn't work, especially when I could read the value with mbpoll just fine.... Until I open the script and saw that the register ranges were hardcoded :-)
This PR will allow to configure the ranges from the .yaml file directly.
