### PR TITLE
Add parameters for boiler circuits working modes (day/night/antifreeze)

### DIFF
--- a/diematic.py
+++ b/diematic.py
@@ -69,6 +69,22 @@ class Boiler:
             output = -output
         return float(output)/10**decimals
 
+
+    def _decode_modeflag(self, value_int):
+       """ Decodes and normalizes the working mode of the boiler.
+            0 -> Anti-freeze
+            2 -> Night
+            4 -> Day
+       """ 
+       if value_int not in (0, 2, 4):
+           return None
+       if value_int == 4:
+           return 1
+       if value_int == 2:
+           return 0
+       if value_int == 0:
+           return -1
+
     def browse_registers(self):
         for register in self.index:
             if not isinstance(register['id'], int):
@@ -88,6 +104,8 @@ class Boiler:
                 if varname and varname.strip(): #test name exists
                     if register['type'] == 'DiematicOneDecimal':
                         setattr(self, varname, self._decode_decimal(register_value, 1))
+                    elif register['type'] == 'DiematicModeFlag':
+                        setattr(self, varname, self._decode_modeflag(register_value))
                     else:
                         setattr(self, varname, register_value)
                 else:

--- a/diematic.yaml.orig
+++ b/diematic.yaml.orig
@@ -14,6 +14,7 @@ modbus:
     baudrate: 9600
     register_ranges:
       - [ 600, 620]
+      - [ 637, 640]
       - [ 700, 702]
 
 influxdb:
@@ -51,6 +52,15 @@ registers:
     - id: 618
       name: temperature_ambiant_circuit_c
       type: DiematicOneDecimal
+    - id: 637
+      name: mode_circuit_a
+      type: DiematicModeFlag
+    - id: 638
+      name: mode_circuit_b
+      type: DiematicModeFlag
+    - id: 639
+      name: mode_circuit_c
+      type: DiematicModeFlag
     - id: 700
       name: bits_base
       type: bits


### PR DESCRIPTION
As detailled in the modbus parameters list, the mode flags uses 0/2/4 values for antifreeze/night/day modes, which I convert to (-1, 0, 1) for easier manipulation.
For example, instead of having two lines on the graph for day /night temperatures for each circuit, you can now have a single line varying with day/night with something like:
```
SELECT (mode_flag * temp_day + (1 - mode_flag) * temp_night) as current_setpoint
```
